### PR TITLE
fix: issue with pathlib, issue with confliting playbook modules

### DIFF
--- a/jinjalint.py
+++ b/jinjalint.py
@@ -338,7 +338,11 @@ def load_ansible_collections_filters():
     import ansible_collections
     for f in Path(ansible_collections.__path__[0]).glob('**/plugins/filter/*.py'):
         if f.stem.startswith('_'): continue
-        parts = f._parts[f._parts.index('ansible_collections') :]
+        if sys.version_info >= (3, 4):
+            # As best that i can tell this changed in 3.4 when pathlib was included [Quien Sabe]
+            parts = list(f.parts[f.parts.index('ansible_collections') :])
+        else:
+            parts = f._parts[f._parts.index('ansible_collections') :]
         parts[-1] = parts[-1].replace('.py', '')
         mod = importlib.import_module('.'.join(parts), package=ansible_collections)
         filters = mod.FilterModule().filters().keys()
@@ -814,7 +818,7 @@ def lint_ansible_directives(v:ruamel.yaml.events.MappingEndEvent, state, pos_sta
         'environment','retries','run_once',
         'failed_when','changed_when','delegate_to', 'until', 'delay',
         'listen', # for handlers
-        'roles','pre_tasks','gather_facts', 'connection', 'tasks', # TODO these are not actually valid inside tasks,
+        'roles','pre_tasks','gather_facts', 'connection', 'tasks','handlers', 'vars_files', 'vars_prompt', # TODO these are not actually valid inside tasks,
         # but listing them here lowers the number of false positives when accidentally
         # running jinjalint.py on a playbook.
         # (we SHOULD be able to handle playbooks, since we are a commit hook for *.yml)


### PR DESCRIPTION
tested with python 3.13.1

make test                                                                                                                                              (fix_false_playbook_conflicting_modules_warning|✚1)
OK testcases/bad/alias-inline.yml
OK testcases/bad/ampersands.yml
OK testcases/bad/debian-lowercase.yml
OK testcases/bad/error-path-reports-inside-vars-not-block.yml
OK testcases/bad/file-items-11.yml
OK testcases/bad/fun-stuff.yml
OK testcases/bad/is-not-abrupt.yml
OK testcases/bad/is-not-not-defined.yml
OK testcases/bad/multiline-broken.yml
OK testcases/bad/namefiledebug.yml
OK testcases/bad/or-pipes.yml
OK testcases/bad/templates/bad-if-scoping.j2
OK testcases/bad/templates/bad-loop-scoping.j2
OK testcases/bad/templates/foo.j2
OK testcases/bad/templates/for-missing-if.j2
OK testcases/bad/templates/if-elif-eof.j2
OK testcases/bad/templates/if-what.j2
OK testcases/bad/templates/namespaced-filters-community-misspelled-ns1.j2
OK testcases/bad/templates/namespaced-filters-community-misspelled-ns2.j2
OK testcases/bad/templates/namespaced-filters-community-misspelled.j2
OK testcases/bad/undefined-alias.yml
OK testcases/bad/unknown-filter.yml
OK testcases/good/alias-inline.yml
OK testcases/good/alias.yml
OK testcases/good/connection_and_tasks.yml
OK testcases/good/empty.yml
OK testcases/good/file-with_items-11.yml
OK testcases/good/for-loop.yml
OK testcases/good/inline-dict.yml
OK testcases/good/is-not.yml
OK testcases/good/known-filter.yml
OK testcases/good/namefiledebug-fixed.yml
OK testcases/good/raw.yml
OK testcases/good/simple-expansions.yml
OK testcases/good/tags.yml
OK testcases/good/tags_strings.yml
OK testcases/good/templates/if-elif-endif.j2
OK testcases/good/templates/if-endif.j2
OK testcases/good/templates/namespaced-filters-community.j2
OK testcases/good/templates/namespaced-filters.j2
